### PR TITLE
build: simplify clean target and configure coverage in pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,30 +12,17 @@ lint: ## Run linters, checks, formatters
 test: ## Run tests
 	poetry run pytest -vv
 
-clean: clean-pyc clean-build clean-test ## Remove all build, test, coverage and Python artifacts
-
-.PHONY: clean-pyc
-clean-pyc: ## Remove Python file artifacts
+clean: ## Clean test, coverage and Python artifacts
+	find . -name '__pycache__' -exec rm -rf {} +
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
-	find . -name '__pycache__' -exec rm -rf {} +
-
-.PHONY: clean-build
-clean-build: ## Remove build artifacts
-	rm -rf build dist .eggs
-	find . -name '*.egg-info' -exec rm -rf  {} +
-	find . -name '*.egg' -exec rm -f {} +
-
-.PHONY: clean-test
-clean-test: ## Remove test and coverage artifacts
-	rm -rf .coverage .mypy_cache .pytest_cache .tox
-
+	rm -rf .coverage .pytest_cache .ruff_cache
 
 .PHONY: coverage
-coverage: ## Check code coverage quickly with the default Python
-	poetry run coverage erase
-	poetry run coverage run --branch --source=monitor -m pytest --junitxml=ut-report.xml tests/
+coverage: ## Run tests with coverage and show report
+	poetry run coverage run -m pytest -vv
+	poetry run coverage report -m
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ With the virtualenv created by Poetry you should have a complete development env
 
 Before committing, you should run tests and linters (linters will also be run by pre-commit hooks):
 
-    docker compose up -d && make test; docker compose down
     make lint
+    docker compose up -d && make test; docker compose down
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 requires-python = ">=3.12,<4"
 
 [tool.poetry]
-packages = [{ include = "monitor" }]
 
 [tool.poetry.dependencies]
 PyYAML = "6.*"
@@ -22,6 +21,19 @@ pytest = "8.*"
 coverage = "7.*"
 pre-commit = "4.*"
 ruff = "0.12.*"
+
+[tool.coverage.run]
+branch = true
+source = ["monitor"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+fail_under = 50
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+]
 
 [tool.ruff]
 lint.ignore = ["E712"]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,5 +1,0 @@
-from monitor import __version__
-
-
-def test_version():
-    assert __version__ == '0.1.0'


### PR DESCRIPTION
Some cleanup and consolidation:
- consolidate clean-* targets into a single clean target
- replace coverage command with coverage run + report
- move coverage configuration into pyproject.toml
- remove meaningless test_monitor.py